### PR TITLE
Improve build time by using rosmsg python module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(vrep_ros_interface)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp image_transport tf cv_bridge
+  roscpp rosmsg image_transport tf cv_bridge
 )
 
 if(NOT DEFINED ENV{VREP_ROOT})

--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,7 @@
   <url>http://www.coppeliarobotics.com</url>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>rosmsg</build_depend>
   <build_depend>libopencv-dev</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>image_transport</build_depend>


### PR DESCRIPTION
Instead of starting subprocesses for `rosmsg`, use the Python interface directly.
The speed improvement is about 30x, in my experience.